### PR TITLE
Setting env with oc set env & add confirmation for cluster scale

### DIFF
--- a/_entries/02-02 project.md
+++ b/_entries/02-02 project.md
@@ -11,6 +11,12 @@ parent-id: lab-ratingapp
 
 Each Azure Red Hat OpenShift cluster has a public hostname that hosts the OpenShift Web Console.
 
+You can use command `az openshift list` to list the clusters in your current Azure subscription.
+
+```sh
+az openshift list -o table
+```
+
 Retrieve your cluster specific hostname. Replace `<cluster name>` and `<resource group>` by those specific to your environment.
 
 ```sh

--- a/_entries/02-04 api.md
+++ b/_entries/02-04 api.md
@@ -35,11 +35,14 @@ oc new-app https://github.com/<your GitHub username>/rating-api --strategy=sourc
 
 {% collapsible %}
 
-Create the `MONGODB_URI` environment variable. This URI should look like `mongodb://[username]:[password]@[endpoint]:27017/ratingsdb`. You'll need to replace the `[usernaame]` and `[password]` with the ones you used when creating the database. You'll also need to replace the `[endpoint]` with the hostname acquired in the previous step
-
-Hit **Save** when done.
-
-![Create a MONGODB_URI environment variable](media/rating-api-envvars.png)
+Create the `MONGODB_URI` environment variable for mongoDB connection string. Please replace the pod name `mongodb-1-hs85j` to the actual pod name. `rating-api` will be able to resolve the service name `mongodb` via internal DNS resolution.
+```sh
+MONGODB_URI=$(oc rsh  mongodb-1-hs85j bash -c 'echo -n mongodb://$MONGODB_USER:$MONGODB_PASSWORD@mongodb:27017/ratingsdb')
+```
+Set the environment variable `MONGODB_URI` for the `rating-api` Deployment Config.
+```sh
+oc set env dc rating-api MONGODB_URI=$MONGODB_URI
+```
 
 {% endcollapsible %}
 

--- a/_entries/02-05 web.md
+++ b/_entries/02-05 web.md
@@ -35,11 +35,11 @@ oc new-app https://github.com/<your GitHub username>/rating-web --strategy=sourc
 
 {% collapsible %}
 
-Create the `API` environment variable. The value of this variable is going to be the hostname/port of the `rating-api` service. Typically, this will look like `http://rating-api.workshop.svc.cluster.local:8080`.
+Create the `API` environment variable for `rating-web` Deployment Config. The value of this variable is going to be the hostname/port of the `rating-api` service.
 
-Hit **Save** when done.
-
-![Create an API environment variable](media/rating-web-envvars.png)
+```sh
+oc set env dc rating-web API=http://rating-api:8080
+```
 
 {% endcollapsible %}
 

--- a/_entries/02-07 scaling.md
+++ b/_entries/02-07 scaling.md
@@ -15,5 +15,22 @@ Run the below on the [Azure Cloud Shell](https://shell.azure.com) to scale your 
 az openshift scale  --name <cluster name> --resource-group <resource group name> --compute-count 5
 ```
 
+After the cluster has scaled successfully. You can run following command to verify the number of application nodes.
+
+```sh
+$ az openshift list -o yaml|grep count -B 1
+```
+You can notice that the value of `count` for `agentPoolProfiles` has been scaled to 5.
+```sh
+- agentPoolProfiles:
+  - count: 5
+--
+    vmSize: Standard_D4s_v3
+  - count: 3
+--
+  masterPoolProfile:
+    count: 3
+```
+
 > **Resources**
 > * [ARO Documentation - Scaling the cluster](https://docs.microsoft.com/en-us/azure/openshift/tutorial-scale-cluster)

--- a/_entries/99 Contributors.md
+++ b/_entries/99 Contributors.md
@@ -12,6 +12,7 @@ The following people have contributed to this workshop, thanks!
 {% githubauthor haroldwongms %}
 {% githubauthor jschluchter %}
 {% githubauthor jamesread %}
+{% githubauthor nichochen%}
 {% githubauthor okashi18 %}
 {% githubauthor sabbour %}
 {% githubauthor wgordon17 %}


### PR DESCRIPTION
Following changes have been made:
1. Set env variable for deployment config with oc set env.
2. Added a step for user to confirm the result of az openshift scale.

Thanks,
Nicholas