### PR TITLE
Update repository references

### DIFF
--- a/_entries/02-00 application.md
+++ b/_entries/02-00 application.md
@@ -13,9 +13,9 @@ The application consists of 3 components:
 
 | Component                                          | Link                                                               |
 |----------------------------------------------------|--------------------------------------------------------------------|
-| A public facing API `rating-api`                   | [GitHub repo](https://github.com/microsoft/rating-api)             |
-| A public facing web frontend `rating-web`          | [GitHub repo](https://github.com/microsoft/rating-web)             |
-| A MongoDB with pre-loaded data                     | [Data](https://github.com/microsoft/rating-api/raw/master/data.tar.gz)   |
+| A public facing API `rating-api`                   | [GitHub repo](https://github.com/MicrosoftDocs/mslearn-aks-workshop-ratings-api)             |
+| A public facing web frontend `rating-web`          | [GitHub repo](https://github.com/MicrosoftDocs/mslearn-aks-workshop-ratings-web)             |
+| A MongoDB with pre-loaded data                     | [Data](https://github.com/MicrosoftDocs/mslearn-aks-workshop-ratings-api/raw/master/data.tar.gz)   |
 
 Once you're done, you'll have an experience similar to the below.
 

--- a/_entries/02-04 api.md
+++ b/_entries/02-04 api.md
@@ -7,7 +7,7 @@ parent-id: lab-ratingapp
 
 The `rating-api` is a NodeJS application that connects to mongoDB to retrieve and rate items. Below are some of the details that you'll need to deploy this.
 
-- `rating-api` on GitHub: <https://github.com/microsoft/rating-api>
+- `rating-api` on GitHub: <https://github.com/MicrosoftDocs/mslearn-aks-workshop-ratings-api>
 - The container exposes port 8080
 - MongoDB connection is configured using an environment variable called `MONGODB_URI`
 
@@ -15,7 +15,7 @@ The `rating-api` is a NodeJS application that connects to mongoDB to retrieve an
 
 To be able to setup CI/CD webhooks, you'll need to fork the application into your personal GitHub repository.
 
-<a class="github-button" href="https://github.com/microsoft/rating-api/fork" data-icon="octicon-repo-forked" data-size="large" aria-label="Fork microsoft/rating-api on GitHub">Fork</a>
+<a class="github-button" href="https://github.com/MicrosoftDocs/mslearn-aks-workshop-ratings-api/fork" data-icon="octicon-repo-forked" data-size="large" aria-label="Fork MicrosoftDocs/mslearn-aks-workshop-ratings-api on GitHub">Fork</a>
 
 ### Use the OpenShift CLI to deploy the `rating-api`
 
@@ -24,7 +24,7 @@ To be able to setup CI/CD webhooks, you'll need to fork the application into you
 {% collapsible %}
 
 ```sh
-oc new-app https://github.com/<your GitHub username>/rating-api --strategy=source
+oc new-app https://github.com/<your GitHub username>/mslearn-aks-workshop-ratings-api --strategy=source --name=rating-api
 ```
 
 ![Create rating-api using oc cli](media/oc-newapp-ratingapi.png)

--- a/_entries/02-05 web.md
+++ b/_entries/02-05 web.md
@@ -16,7 +16,7 @@ The `rating-web` is a NodeJS application that connects to the `rating-api`. Belo
 
 To be able to setup CI/CD webhooks, you'll need to fork the application into your personal GitHub repository.
 
-<a class="github-button" href="https://github.com/MicrosoftDocs/mslearn-aks-workshop-ratings-web/fork" data-icon="octicon-repo-forked" data-size="large" aria-label="Fork microsoft/rating-web on GitHub">Fork</a>
+<a class="github-button" href="https://github.com/MicrosoftDocs/mslearn-aks-workshop-ratings-web/fork" data-icon="octicon-repo-forked" data-size="large" aria-label="Fork MicrosoftDocs/mslearn-aks-workshop-ratings-web on GitHub">Fork</a>
 
 ### Modify Dockerfile in your repository
 
@@ -29,8 +29,8 @@ To be able to setup CI/CD webhooks, you'll need to fork the application into you
 1. Clone the Git repository locally and change to repo directory
 
 ```sh
-git clone https://github.com/user-name/rating-web.git
-cd rating-web
+git clone https://github.com/<your GitHub username>/mslearn-aks-workshop-ratings-web.git
+cd mslearn-aks-workshop-ratings-web
 ```
 
 2. Download updated Dockerfile and Footer.vue files
@@ -62,7 +62,7 @@ git push
 {% collapsible %}
 
 ```sh
-oc new-app https://github.com/<your GitHub username>/rating-web --strategy=docker
+oc new-app https://github.com/<your GitHub username>/mslearn-aks-workshop-ratings-web --strategy=docker --name=rating-web
 ```
 
 The build will take between 5-10 minutes


### PR DESCRIPTION
The workshop uses deprecated references to rating-web and rating-api repositories, and `oc new-app` commands are missing the `--name` attribute to ensure that `Deployments` and `Services` get the correct name. I see #80 open but there are merge conflicts, so thought this would be easier to merge right in :)