### PR TITLE
Fix SASS deprecated div without calc

### DIFF
--- a/_sass/modules/_mixins.scss
+++ b/_sass/modules/_mixins.scss
@@ -26,7 +26,7 @@
     position: relative;
     width: $containerwidth;
     height: 0;
-    padding: (($ratioheight / $ratiowidth) * $containerwidth) 0 0 0;
+    padding: (calc($ratioheight / $ratiowidth) * $containerwidth) 0 0 0;
 }
 // @include paddinghack(width, ratiowidth, ratioheight)
 


### PR DESCRIPTION
A simple fix that prevents a warning on `jekyll build`. 

Merging without a reviewer as I'm quite sure this should not create any objections. 