### PR TITLE
Fix jekyll build with jekyll-action, and update actions to remove deprecation warnings.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: 'Checkout the latest code'
-      uses: actions/checkout@v2      
+      uses: actions/checkout@v3.3.0
       
     - name: 'Inject slug/short variables'
-      uses: rlespinasse/github-slug-action@v2.x
+      uses: rlespinasse/github-slug-action@v4.4.0
         
     - name: 'Update site with run number'
       run: |
@@ -24,7 +24,7 @@ jobs:
         
     # Use GitHub Actions' cache to shorten build times and decrease load on servers
     - name: 'Cache gems'
-      uses: actions/cache@v2
+      uses: actions/cache@v3.2.3
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
@@ -32,6 +32,6 @@ jobs:
           ${{ runner.os }}-gems-
           
     - name: 'Build and publish Jekyll to GitHub Pages'
-      uses: helaili/jekyll-action@v2
+      uses: helaili/jekyll-action@v2.4
       with: 
        token: ${{ secrets.GITHUB_TOKEN }}

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,8 @@ source "https://rubygems.org"
 
 # gem "rails"
 
-gem "jekyll", "~> 4.2"
+gem "jekyll", "~> 4.3"
+
+# Lock jekyll-sass-converter at v2, because jekyll-action is built on alpine, 
+# which uses musl, not libc, and it fails to build.
+gem "jekyll-sass-converter", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,6 @@ GEM
     eventmachine (1.2.7)
     ffi (1.15.5)
     forwardable-extended (2.6.0)
-    google-protobuf (3.21.12-x86_64-linux)
     http_parser.rb (0.8.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -31,8 +30,8 @@ GEM
       safe_yaml (~> 1.0)
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
-    jekyll-sass-converter (3.0.0)
-      sass-embedded (~> 1.54)
+    jekyll-sass-converter (2.2.0)
+      sassc (> 2.0.1, < 3.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (2.4.0)
@@ -53,8 +52,8 @@ GEM
     rexml (3.2.5)
     rouge (4.0.1)
     safe_yaml (1.0.5)
-    sass-embedded (1.57.1-x86_64-linux-gnu)
-      google-protobuf (~> 3.21)
+    sassc (2.4.0)
+      ffi (~> 1.9)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.4.2)
@@ -64,7 +63,8 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  jekyll (~> 4.2)
+  jekyll (~> 4.3)
+  jekyll-sass-converter (~> 2.0)
 
 BUNDLED WITH
    2.3.12

--- a/_sass/modules/_mixins.scss
+++ b/_sass/modules/_mixins.scss
@@ -26,7 +26,7 @@
     position: relative;
     width: $containerwidth;
     height: 0;
-    padding: (calc($ratioheight / $ratiowidth) * $containerwidth) 0 0 0;
+    padding: (($ratioheight / $ratiowidth) * $containerwidth) 0 0 0;
 }
 // @include paddinghack(width, ratiowidth, ratioheight)
 


### PR DESCRIPTION
I validated this against a temporary testing repository and everything works as expected - no deprecation warnings, and a healthy Jekyll build. 

However, if this commit does not work, I'll revert the last 3. 