### PR TITLE
Patch command to resolve ratings-api port 3000 issue #107

### DIFF
--- a/_entries/02-04 api.md
+++ b/_entries/02-04 api.md
@@ -74,6 +74,18 @@ The service will be accessible at the following DNS name over port 8080: `rating
 
 {% endcollapsible %}
 
+### Update `rating-api` service pod port
+
+{% collapsible %}
+The rating-api pod itself runs on port 3000. You will need to update the SVC for the rating-api to listen on port 8080 and forward to port 3000 on the running pod.
+
+Use this patch command to do that from the CLI
+```sh
+oc patch service/rating-api --patch '{"spec": {"ports": [{"name": "8080-tcp","protocol": "TCP", "port": 8080, "targetPort": 3000}]}}'
+oc get svc rating-api
+
+```
+{% endcollapsible %}
 ### Setup GitHub webhook
 
 To trigger S2I builds when you push code into your GitHib repo, you'll need to setup the GitHub webhook.

--- a/_entries/99 Contributors.md
+++ b/_entries/99 Contributors.md
@@ -13,6 +13,7 @@ The following people have contributed to this workshop, thanks!
 {% githubauthor jschluchter %}
 {% githubauthor jamesread %}
 {% githubauthor nichochen%}
+{% githubauthor mandibuswell%}
 {% githubauthor 0kashi %}
 {% githubauthor sabbour %}
 {% githubauthor wgordon17 %}


### PR DESCRIPTION
Update 02-04 api.md with patch command to change pod port to 3000
There may be a way to have the service default to port 3000, I am not sure how to do that - but for now this will work by patching the automatically created svc for ratings-api
Fix for 
https://github.com/microsoft/aroworkshop/issues/107